### PR TITLE
ImageMakerTest: Fix undefined itkFactoryRegistration link error

### DIFF
--- a/Modules/CLI/ImageMaker/Testing/Cxx/CMakeLists.txt
+++ b/Modules/CLI/ImageMaker/Testing/Cxx/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CLP ${MODULE_NAME})
 
 #-----------------------------------------------------------------------------
 add_executable(${CLP}Test ${CLP}Test.cxx)
-target_link_libraries(${CLP}Test ${CLP}Lib)
+target_link_libraries(${CLP}Test ${CLP}Lib ${SlicerExecutionModel_EXTRA_EXECUTABLE_TARGET_LIBRARIES})
 set_target_properties(${CLP}Test PROPERTIES LABELS ${CLP})
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
This commit fixes the following link error:

```
Undefined symbols for architecture x86_64:
"itk::itkFactoryRegistration()", referenced from:
_main in ImageMakerTest.cxx.o
ld: symbol(s) not found for architecture x86_64
```